### PR TITLE
Install pinned deps before README update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pipreqs poetry semver toml
+          python -m pip install -r requirements.txt
 
       - name: Determine release version
         id: versioning


### PR DESCRIPTION
## Summary
- install pinned project dependencies in the release-prep workflow before running readme_updater.py
- prevent pipreqs from resolving newer incompatible package versions from PyPI during automated version bumps
