### PR TITLE
Preserve pinned Python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ summary = "Tleco: Tleco stands for both in the fire and rise in the nahuatl lang
 license = "GPL-3.0-only"
 requires-python = ">=3.9"
 classifiers = [ "Programming Language :: Rust", "Programming Language :: Python :: Implementation :: CPython", "Programming Language :: Python :: Implementation :: PyPy",]
-dependencies = [ "astropy == 6.1.4", "ebltable == 0.5.2", "pytest == 8.3.3", "toml == 0.10.2", "tqdm == 4.66.5",]
+dependencies = [ "astropy == 6.1.4", "ebltable == 0.5.2", "matplotlib == 3.9.2", "numpy == 2.1.2", "pytest == 8.3.3", "scipy == 1.14.1", "toml == 0.10.2", "tqdm == 4.66.5",]
 [[project.authors]]
 name = "Jesus M Rueda-Becerril"
 email = "jm.ruebe@gmail.com"
@@ -34,7 +34,10 @@ license = "GPL-3.0-only"
 python = "^3.10"
 astropy = "6.1.4"
 ebltable = "0.5.2"
+matplotlib = "3.9.2"
+numpy = "2.1.2"
 pytest = "8.3.3"
+scipy = "1.14.1"
 toml = "0.10.2"
 tqdm = "4.66.5"
 maturin = "1.5"

--- a/readme_updater.py
+++ b/readme_updater.py
@@ -280,6 +280,8 @@ def generate_requirements_txt(project_path, exclude_dirs=None,  additional_deps=
     """
     Uses pipreqs to generate requirements.txt for the given project path.
     """
+    requirements_path = f"{project_path}/requirements.txt"
+    existing_requirements = read_requirements(requirements_path) if os.path.exists(requirements_path) else []
     command = ['pipreqs', '--force', '--use-local', project_path]
 
     if exclude_dirs:
@@ -288,11 +290,18 @@ def generate_requirements_txt(project_path, exclude_dirs=None,  additional_deps=
 
     subprocess.run(command, check=True)
 
+    generated_requirements = read_requirements(requirements_path)
+    merged_requirements = {package_name: version for package_name, version in existing_requirements}
+    for package_name, version in generated_requirements:
+        merged_requirements[package_name] = version
     if additional_deps:
-        requirements_path = f"{project_path}/requirements.txt"
-        with open(requirements_path, "a") as req_file:
-            for dep in additional_deps:
-                req_file.write(f"{dep}\n")
+        for dep in additional_deps:
+            package_name, version = dep.split("==", 1)
+            merged_requirements[package_name.strip()] = version.strip()
+
+    with open(requirements_path, "w", encoding="utf-8") as req_file:
+        for package_name in sorted(merged_requirements):
+            req_file.write(f"{package_name}=={merged_requirements[package_name]}\n")
 
 def read_requirements(requirements_path):
     requirements = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 astropy==6.1.4
 ebltable==0.5.2
+matplotlib==3.9.2
+numpy==2.1.2
 pytest==8.3.3
+scipy==1.14.1
 toml==0.10.2
 tqdm==4.66.5
 maturin==1.5


### PR DESCRIPTION
## Summary
- restore the dropped numpy, matplotlib, and scipy pins in requirements.txt and pyproject.toml
- make readme_updater preserve existing pinned requirements when pipreqs misses imports
- prevent future release-prep runs from silently dropping required Python dependencies
